### PR TITLE
Allow clients to specify addresses to be used for send and receive in…

### DIFF
--- a/openpgm/pgm/examples/blocksyncrecv.c
+++ b/openpgm/pgm/examples/blocksyncrecv.c
@@ -267,12 +267,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/daytime.c
+++ b/openpgm/pgm/examples/daytime.c
@@ -381,13 +381,7 @@ create_sock (void)
 /* assign socket to specified address */
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
-	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),        /* tx interface */

--- a/openpgm/pgm/examples/enonblocksyncrecv.c
+++ b/openpgm/pgm/examples/enonblocksyncrecv.c
@@ -298,12 +298,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/enonblocksyncrecvmsg.c
+++ b/openpgm/pgm/examples/enonblocksyncrecvmsg.c
@@ -293,12 +293,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/enonblocksyncrecvmsgv.c
+++ b/openpgm/pgm/examples/enonblocksyncrecvmsgv.c
@@ -300,12 +300,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/pgmping.cc
+++ b/openpgm/pgm/examples/pgmping.cc
@@ -713,12 +713,7 @@ on_startup (
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/pgmrecv.c
+++ b/openpgm/pgm/examples/pgmrecv.c
@@ -378,12 +378,7 @@ on_startup (
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/pgmsend.c
+++ b/openpgm/pgm/examples/pgmsend.c
@@ -246,12 +246,7 @@ create_pgm_socket (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/pnonblocksyncrecv.c
+++ b/openpgm/pgm/examples/pnonblocksyncrecv.c
@@ -297,12 +297,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/purinrecv.c
+++ b/openpgm/pgm/examples/purinrecv.c
@@ -402,12 +402,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/purinsend.c
+++ b/openpgm/pgm/examples/purinsend.c
@@ -231,12 +231,7 @@ create_sock (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/shortcakerecv.c
+++ b/openpgm/pgm/examples/shortcakerecv.c
@@ -350,12 +350,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),        /* tx interface */

--- a/openpgm/pgm/examples/snonblocksyncrecv.c
+++ b/openpgm/pgm/examples/snonblocksyncrecv.c
@@ -355,12 +355,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/include/pgm/socket.h
+++ b/openpgm/pgm/include/pgm/socket.h
@@ -55,15 +55,26 @@ struct pgm_sockaddr_t {
 struct pgm_addrinfo_t {
 	sa_family_t				ai_family;
 	uint32_t				ai_recv_addrs_len;
-	struct group_source_req* restrict	ai_recv_addrs;
+	struct pgm_group_source_req* restrict	ai_recv_addrs;
 	uint32_t				ai_send_addrs_len;
-	struct group_source_req* restrict	ai_send_addrs;
+	struct pgm_group_source_req* restrict	ai_send_addrs;
+};
+
+struct pgm_group_source_req
+{
+	uint32_t		gsr_interface;	/* interface index */
+	struct sockaddr_storage	gsr_group;	/* group address */
+	struct sockaddr_storage	gsr_source;	/* group source */
+	struct sockaddr_storage	gsr_addr;	/* interface address */
 };
 
 struct pgm_interface_req_t {
 	uint32_t				ir_interface;
 	uint32_t				ir_scope_id;
+	struct sockaddr_storage			ir_address;
 };
+
+#define	PGM_HAS_IR_ADDRESS	1
 
 struct pgm_fecinfo_t {
 	uint8_t					block_size;

--- a/openpgm/pgm/socket.c
+++ b/openpgm/pgm/socket.c
@@ -2166,7 +2166,9 @@ pgm_bind3 (
 		pgm_trace (PGM_LOG_ROLE_NETWORK,_("Binding receive socket to IN6ADDR_ANY"));
 	}
 #else
-	if (!pgm_if_indextoaddr (recv_req->ir_interface,
+	if (recv_req->ir_address.ss_family != AF_UNSPEC)
+		memcpy(&recv_addr, &recv_req->ir_address, pgm_sockaddr_len (recv_req->ir_address));
+	else if (!pgm_if_indextoaddr (recv_req->ir_interface,
 			         sock->family,
 				 recv_req->ir_scope_id,
 			         &recv_addr.sa,
@@ -2221,7 +2223,9 @@ pgm_bind3 (
 /* keep a copy of the original address source to re-use for router alert bind */
 	memset (&send_addr, 0, sizeof(send_addr));
 
-	if (!pgm_if_indextoaddr (send_req->ir_interface,
+	if (send_req->ir_address.ss_family != AF_UNSPEC)
+		memcpy(&send_addr, &send_req->ir_address, pgm_sockaddr_len ((struct sockaddr *)&send_req->ir_address));
+	else if (!pgm_if_indextoaddr (send_req->ir_interface,
 				 sock->family,
 				 send_req->ir_scope_id,
 				 (struct sockaddr*)&send_addr,


### PR DESCRIPTION
… pgm_bind3().

Add an extra field ir_address to pgm_interface_req_t and define preprocessor
symbol PGM_HAS_IR_ADDRESS so a client can know it is present. Also add
the address to the information returned by pgm_getaddrinfo(), so that different
addresses on a single network device can be specified.

Also modify interface name parsing to allow for interfaces to have more
than one address.

When binding, if the address family is not AF_UNDEF, the address will be
used for underlying socket binding, rather than using the first address
on the interface indexed by ir_interface.

To match this, define pgm_group_source_req, add gsr_addr and use that in
pgm_addrinfo_t instead of group_source_req.

Fixes #37.