### PR TITLE
Add support for AIX, building with xlc or gcc.

### DIFF
--- a/openpgm/pgm/Makefile.am
+++ b/openpgm/pgm/Makefile.am
@@ -54,6 +54,10 @@ libpgm_noinst_la_SOURCES = \
 	histogram.c \
 	version.c
 
+if AIX_XLC
+libpgm_noinst_la_SOURCES += fetch_and_add_h.s
+endif
+
 share_includedir = $(includedir)/pgm-@RELEASE_INFO@/pgm
 share_include_HEADERS = \
 	include/pgm/atomic.h \

--- a/openpgm/pgm/configure.ac
+++ b/openpgm/pgm/configure.ac
@@ -4,6 +4,7 @@
 #  Ubuntu 10 : v2.65
 #   OSX 10.6 : v2.61
 # Solaris 10 : v2.59
+#        AIX : v2.69
 AC_PREREQ([2.61])
 AC_INIT([OpenPGM], [m4_esyscmd([perl version.pl %major.%minor.%micro])], [openpgm-dev@googlegroups.com], [openpgm], [http://code.google.com/p/openpgm/])
 AC_CONFIG_SRCDIR([reed_solomon.c])
@@ -26,6 +27,7 @@ AC_SUBST([VERSION_MICRO], [m4_esyscmd([perl version.pl %micro])])
 # Checks for programs.
 AC_PROG_CC
 AC_PROG_CC_C99
+AM_PROG_AS
 AC_PROG_LIBTOOL
 AC_PATH_PROG(PERL, perl)
 AC_PATH_PROG(PYTHON, python)
@@ -40,6 +42,7 @@ AC_SUBST(PYTHON)
 # Apply system specific rules.
 AC_CANONICAL_HOST
 CFLAGS="$CFLAGS -D_REENTRANT"
+AM_CONDITIONAL([AIX_XLC], [false])
 case "$host_os" in
 linux*)
 	CFLAGS="$CFLAGS -D_XOPEN_SOURCE=600 -D_BSD_SOURCE"
@@ -51,6 +54,12 @@ solaris*)
 	AC_SEARCH_LIBS([inet_aton], [resolv])
 	AC_SEARCH_LIBS([kstat_open], [kstat])
 	;;
+aix*)
+	if test "x$GCC" != "xyes"; then
+		AM_CONDITIONAL([AIX_XLC], [true])
+		CCASFLAGS="$CCASFLAGS -qarch=ppc"
+	fi
+        ;;
 *)
 	;;
 esac
@@ -86,9 +95,7 @@ AC_TYPE_UINT8_T
 # Checks for library functions.
 # TODO: gettext() fails out-of-the-box from AutoConf.
 #AM_GNU_GETTEXT
-AC_FUNC_MALLOC
 AC_FUNC_MMAP
-AC_FUNC_REALLOC
 AC_FUNC_STRERROR_R
 AC_CHECK_FUNCS([atexit clock_gettime floor ftime gethostbyaddr gethostbyname gethostname gettimeofday inet_ntoa memmove memset regcomp select setenv setlocale socket sqrt stpcpy strcasecmp strchr strdup strerror strncasecmp strpbrk strrchr strstr strtol strtoul strtoull])
 
@@ -100,6 +107,26 @@ AC_COMPILE_IFELSE(
 	[AC_MSG_RESULT([yes])
 		CFLAGS="$CFLAGS -DHAVE_PTHREAD_SPINLOCK"],
 	[AC_MSG_RESULT([no])])
+# sa_len struct sockaddr?
+AC_MSG_CHECKING([for sa_len member in struct sockaddr])
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM([[#include <sys/types.h>
+#include <sys/socket.h>]],			\
+		[[struct sockaddr sa;
+		  sa.sa_len = 0;]])],
+	[AC_MSG_RESULT([yes])
+		CFLAGS="$CFLAGS -DHAVE_SOCKADDR_SA_LEN"],
+	[AC_MSG_RESULT([no])])
+# __ss_family and __ss_len in struct sockaddr_storage?
+AC_MSG_CHECKING([for __ss_family member in struct sockaddr_storage])
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM([[#include <sys/socket.h>]],
+		[[struct sockaddr_storage s;
+		  s.__ss_family = 0;]])],
+	[AC_MSG_RESULT([yes])
+		AC_DEFINE_UNQUOTED(ss_family, __ss_family,
+				   [For systems that have __ss_family as member of 'struct sockaddr_storage'])],
+	[AC_MSG_RESULT([no])])
 # NSS protocol lookup
 AC_CHECK_FUNCS([getprotobyname_r])
 if test "x$ac_cv_func_getprotobyname_r" = "xyes"; then
@@ -109,6 +136,13 @@ AC_COMPILE_IFELSE(
 		[[struct protoent *pe = getprotobyname_r ((const char*)0, (struct protoent*)0, (char*)0, (int)0);]])],
 	[AC_MSG_RESULT([yes])
 		CFLAGS="$CFLAGS -DGETPROTOBYNAME_R_STRUCT_PROTOENT_P"],
+	[AC_MSG_RESULT([no])])
+AC_MSG_CHECKING([whether getprotobyname_r takes 3 parameters])
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM([[#include <netdb.h>]],
+		[[getprotobyname_r ((const char*)0, (struct protoent*)0, (struct protoent_data*)0);]])],
+	[AC_MSG_RESULT([yes])
+		CFLAGS="$CFLAGS -DHAVE_GETPROTOBYNAME_R3"],
 	[AC_MSG_RESULT([no])])
 fi
 # NSS networks lookup, IPv4 only
@@ -149,14 +183,15 @@ AC_CHECK_FUNCS([pselect])
 AC_CHECK_FILES([/dev/rtc])
 AC_MSG_CHECKING([for RDTSC instruction])
 case "$host_os" in
-darwin*)
+darwin* | aix*)
 	AC_MSG_RESULT([no])
 	;;
 *)
 AC_COMPILE_IFELSE(
 	[AC_LANG_PROGRAM(,[[unsigned long lo, hi;
 __asm__ __volatile__ ("rdtsc" : "=a" (lo), "=d" (hi));]])],
-	[AC_MSG_RESULT([yes])
+:1
+[AC_MSG_RESULT([yes])
 		CFLAGS="$CFLAGS -DHAVE_RDTSC"],
 	[AC_MSG_RESULT([no])])
 	;;
@@ -292,6 +327,8 @@ AC_COMPILE_IFELSE(
 /* GCC assembler */
 #elif defined( __sun )
 /* Solaris intrinsic */
+#elif defined( _AIX )
+/* AIX intrinsic */
 #elif defined( __APPLE__ )
 /* Darwin intrinsic */
 #elif defined( __GNUC__ ) && ( __GNUC__ * 100 + __GNUC_MINOR__ >= 401 )

--- a/openpgm/pgm/fetch_and_add_h.s
+++ b/openpgm/pgm/fetch_and_add_h.s
@@ -1,0 +1,67 @@
+# Implementation of AIX fetch_and_add_h().
+#
+# fetch_and_add_h() is declared in sys/atomic_op.h on AIX 5.2 but
+# isn't in the standard runtime libraries. fetch_and_add() is present.
+# So provide an implementation based on the GCC __sync_fetch_and_add().
+#
+# xlc V6 (yes, old, I know) doesn't do inline assembler, hence the need
+# to put this in a separate source file.
+        
+        .toc
+        .file "fetch_and_add_h.s"
+
+        .globl .fetch_and_add_h
+
+        .csect fetchaddh{PR}
+        # short fetch_and_add_h(*short p, short v)
+        # {
+        #    short res = *p;
+        #    *p += v;
+        #    return res;
+        # }
+.fetch_and_add_h:
+        lwsync
+
+        li      0, 0
+        ori     0, 0, 0xffff          # R0 = 0xffff
+
+        # lwarx/stwcx deal in 32bit words. But the pointer to the
+        # value of interest will be on a 16 or 32bit boundary.
+        # So we will load the 32bit words containing it, and note
+        # whether we need to deal with the high or low 16 bit short
+        # therein. First we set R9 to a shift (16 or 0) and R0 to a mask.
+        # If on a 16bit boundary, the quantity of interest will be in the
+        # low half of the 32bit word, and the high half on a 32bit boundary.
+        #
+        # So start by setting R9 to 16 if short is high part of word,
+        # 0 if low part. Also set R0 to the matching mask.
+        rlwinm  9, 3, 3, 27, 27       # Bit 1 of pointer, shift left 3.
+        xori    9, 9, 16
+        slw     0, 0, 9
+
+        # Adjust R3 to the address of the 32bit word
+        rlwinm  3, 3, 0, 0, 29
+
+        # Move the value to be added to the matching half word.
+        slw     4, 4, 9
+
+        # Grab the word of interest into R11, add into R10,
+        # and replace the non-result half with the original content.
+again:
+        lwarx   11, 0, 3
+        add     10, 11, 4
+        and     10, 10, 0
+        andc    8, 11, 0
+        or      10, 10, 8
+
+        # Try the store, loop if fails.
+        stwcx.  10, 0, 3
+        bne     again
+
+        # Written new value, make sure all further reads get it.
+        isync
+
+        # Get the half of the original value to return into R9.
+        slw     9, 11, 9
+        rlwinm  3, 9, 0, 0xffff
+        blr

--- a/openpgm/pgm/getnodeaddr.c
+++ b/openpgm/pgm/getnodeaddr.c
@@ -28,6 +28,10 @@
 #endif
 #include <errno.h>
 #ifndef _WIN32
+#ifdef _AIX
+#   define IP_MULTICAST
+#   define _USE_IRS
+#endif
 #	include <netdb.h>
 #endif
 #include <impl/i18n.h>

--- a/openpgm/pgm/getprotobyname.c
+++ b/openpgm/pgm/getprotobyname.c
@@ -59,6 +59,12 @@ _pgm_native_getprotobyname (
 	struct protoent protobuf;
 	if (NULL == (pe = getprotobyname_r (name, &protobuf, buf, BUFSIZ)))
 		return NULL;
+#elif defined(HAVE_GETPROTOBYNAME_R3)
+	struct protoent protobuf;
+	struct protoent_data protodata;
+	if (0 != getprotobyname_r (name, &protobuf, &protodata))
+		return NULL;
+	pe = &protobuf;
 #elif defined( HAVE_GETPROTOBYNAME_R )
 	char buf[BUFSIZ];
 	struct protoent protobuf;
@@ -83,6 +89,9 @@ _pgm_native_getprotobyname (
 	}
 	*q = NULL;
 	proto.p_proto = pe->p_proto;
+#if defined(HAVE_GETPROTOBYNAME_R3)
+	endprotoent_r(&protodata);
+#endif /* HAVE_GETPROTOBYNAME_R3 */
 	return &proto;
 }
 

--- a/openpgm/pgm/hashtable.c
+++ b/openpgm/pgm/hashtable.c
@@ -295,7 +295,7 @@ pgm_str_equal (
 	const void* restrict p2
 	)
 {
-	const char *restrict s1 = p1, *restrict s2 = p2;
+	const char *s1 = p1, *s2 = p2;
 	return (strcmp (s1, s2) == 0);
 }
 

--- a/openpgm/pgm/if.c
+++ b/openpgm/pgm/if.c
@@ -31,6 +31,9 @@
 #include <ctype.h>
 #include <stdio.h>
 #ifndef _WIN32
+#ifdef _AIX
+#       define IP_MULTICAST
+#endif
 #	include <sys/types.h>
 #	include <sys/socket.h>
 #	include <netdb.h>		/* _GNU_SOURCE for EAI_NODATA */
@@ -63,7 +66,11 @@ struct interface_req {
 #endif
 
 /* ff08::1 */
+#ifdef _AIX
+#define IF6_DEFAULT_INIT { { .u6_addr8 = { 0xff,8,0,0,0,0,0,0,0,0,0,0,0,0,0,1 } } }
+#else
 #define IF6_DEFAULT_INIT { { { 0xff,8,0,0,0,0,0,0,0,0,0,0,0,0,0,1 } } }
+#endif
 const struct in6_addr if6_default_group_addr = IF6_DEFAULT_INIT;
 
 

--- a/openpgm/pgm/include/impl/ip.h
+++ b/openpgm/pgm/include/impl/ip.h
@@ -142,7 +142,7 @@ struct pgm_udphdr
 
 PGM_STATIC_ASSERT(sizeof(struct pgm_udphdr) == 8);
 
-#if (defined( __GNUC__ ) && ( __GNUC__ >= 4 )) && !defined( __sun ) && !defined( __CYGWIN__ )
+#if ((defined( __GNUC__ ) && ( __GNUC__ >= 4 )) && !defined( __sun ) && !defined( __CYGWIN__ )) || defined (__xlc__) || defined(__xlC__)
 #	pragma pack(pop)
 #else
 #	pragma pack()

--- a/openpgm/pgm/include/impl/sockaddr.h
+++ b/openpgm/pgm/include/impl/sockaddr.h
@@ -34,7 +34,7 @@
 #	include <sys/socket.h>
 #	include <netdb.h>
 #endif
-#if defined( __APPLE__ ) || defined( __FreeBSD__ )
+#if defined( __APPLE__ ) || defined( __FreeBSD__ ) || defined(_AIX)
 /* incomplete RFC 3678 API support */
 #	include <pgm/in.h>
 #endif

--- a/openpgm/pgm/include/pgm/atomic.h
+++ b/openpgm/pgm/include/pgm/atomic.h
@@ -33,6 +33,8 @@
 
 #if defined( __sun )
 #	include <atomic.h>
+#elif defined( _AIX ) && ( !defined( __GNUC__ ) ||  (__GNUC__ * 100 + __GNUC_MINOR__ < 401 ))
+#	include <sys/atomic_op.h>
 #elif defined( __APPLE__ )
 #	include <libkern/OSAtomic.h>
 #elif defined( _MSC_VER )
@@ -81,6 +83,8 @@ pgm_atomic_exchange_and_add32 (
 #elif defined( __GNUC__ ) && ( __GNUC__ * 100 + __GNUC_MINOR__ >= 401 )
 /* GCC 4.0.1 intrinsic */
 	return __sync_fetch_and_add (atomic, val);
+#elif defined( _AIX )
+	return fetch_and_add((atomic_p)atomic, val);
 #elif defined( _WIN32 )
 /* Windows intrinsic */
 	return _InterlockedExchangeAdd ((volatile LONG*)atomic, val);
@@ -116,6 +120,8 @@ pgm_atomic_add32 (
 #elif defined( __GNUC__ ) && ( __GNUC__ * 100 + __GNUC_MINOR__ >= 401 )
 /* interchangable with __sync_fetch_and_add () */
 	__sync_add_and_fetch (atomic, val);
+#elif defined( _AIX )
+	fetch_and_add((atomic_p)atomic, val);
 #elif defined( _WIN32 )
 	_InterlockedExchangeAdd ((volatile LONG*)atomic, val);
 #endif
@@ -152,6 +158,8 @@ pgm_atomic_inc32 (
 	OSAtomicIncrement32Barrier ((volatile int32_t*)atomic);
 #elif defined( __GNUC__ ) && ( __GNUC__ * 100 + __GNUC_MINOR__ >= 401 )
 	pgm_atomic_add32 (atomic, 1);
+#elif defined( _AIX )
+	fetch_and_add((atomic_p)atomic, 1);
 #elif defined( _WIN32 )
 	_InterlockedIncrement ((volatile LONG*)atomic);
 #endif
@@ -182,6 +190,8 @@ pgm_atomic_dec32 (
 	OSAtomicDecrement32Barrier ((volatile int32_t*)atomic);
 #elif defined( __GNUC__ ) && ( __GNUC__ * 100 + __GNUC_MINOR__ >= 401 )
 	pgm_atomic_add32 (atomic, (uint32_t)-1);
+#elif defined( _AIX )
+	fetch_and_add((atomic_p)atomic, -1);
 #elif defined( _WIN32 )
 	_InterlockedDecrement ((volatile LONG*)atomic);
 #endif

--- a/openpgm/pgm/include/pgm/macros.h
+++ b/openpgm/pgm/include/pgm/macros.h
@@ -35,7 +35,7 @@
  * http://gcc.gnu.org/onlinedocs/gcc/Function-Attributes.html
  */
 
-#if !defined(__APPLE__) && ((__GNUC__ > 2) || (__GNUC__ == 2 && __GNUC_MINOR__ >= 96))
+#if !defined(__APPLE__) && !defined(_AIX) && ((__GNUC__ > 2) || (__GNUC__ == 2 && __GNUC_MINOR__ >= 96))
 
 /* No side-effects except return value, may follow pointers and read globals */
 #	define PGM_GNUC_PURE			__attribute__((__pure__))

--- a/openpgm/pgm/include/pgm/packet.h
+++ b/openpgm/pgm/include/pgm/packet.h
@@ -28,7 +28,13 @@
 #ifndef _WIN32
 #	include <sys/socket.h>
 #	include <netinet/in.h>
+#ifdef _AIX
+#define	_IP_FIRSTFOUR_ONLY
+#endif
 #	include <netinet/ip.h>
+#ifdef _AIX
+#undef	_IP_FIRSTFOUR_ONLY
+#endif
 #endif
 #include <pgm/types.h>
 
@@ -445,7 +451,7 @@ struct pgm_opt6_path_nla {
 };
 
 
-#if (defined( __GNUC__ ) && ( __GNUC__ >= 4 )) && !defined( __sun ) && !defined( __CYGWIN__ )
+#if ((defined( __GNUC__ ) && ( __GNUC__ >= 4 )) && !defined( __sun ) && !defined( __CYGWIN__ )) || defined( __xlc__ ) || defined( __xlC__ )
 #	pragma pack(pop)
 #else
 #	pragma pack()

--- a/openpgm/pgm/include/pgm/socket.h
+++ b/openpgm/pgm/include/pgm/socket.h
@@ -37,6 +37,9 @@ struct pgm_fecinto_t;
 #	include <sys/epoll.h>
 #endif
 #ifndef _WIN32
+#ifdef _AIX
+#   define IP_MULTICAST
+#endif
 #	include <sys/select.h>
 #	include <sys/socket.h>
 #endif

--- a/openpgm/pgm/openpgm.spec.in
+++ b/openpgm/pgm/openpgm.spec.in
@@ -18,7 +18,12 @@ available at www.ietf.org.
 %package devel
 Summary:  Development files and static library for the OpenPGM library
 Group:    Development/Libraries
-Requires: %{name} = %{version}-%{release}, pkgconfig
+Requires: %{name} = %{version}-%{release}
+%ifos aix5.2 || %ifos aix5.3 || %ifos aix6.1 || %ifos aix7.1
+Requires: pkg-config
+%else
+Requires: pkgconfig
+%endif
 
 %description devel
 OpenPGM is an open source implementation of the 
@@ -41,10 +46,14 @@ This package contains OpenPGM related development libraries and header files.
 %makeinstall
 
 %post
+%ifos linux
 /sbin/ldconfig
+%endif
 
 %postun
+%ifos linux
 /sbin/ldconfig
+%endif
 
 %clean
 [ "%{buildroot}" != "/" ] && %{__rm} -rf %{buildroot}
@@ -53,8 +62,13 @@ This package contains OpenPGM related development libraries and header files.
 %defattr(-,root,root,-)
 
 # libraries
+%ifos aix5.2 || %ifos aix5.3 || %ifos aix6.1 || %ifos aix7.1
+%{_libdir}/libpgm.a
+%{_libdir}/libpgm-@RELEASE_INFO@.a
+%else
 %{_libdir}/libpgm-@RELEASE_INFO@.so.0
 %{_libdir}/libpgm-@RELEASE_INFO@.so.0.0.@VERSION_MICRO@
+%endif
 
 %files devel
 %defattr(-,root,root,-)
@@ -81,11 +95,18 @@ This package contains OpenPGM related development libraries and header files.
 %{_includedir}/pgm-@RELEASE_INFO@/pgm/wininttypes.h
 %{_includedir}/pgm-@RELEASE_INFO@/pgm/zinttypes.h
 
+%ifos aix5.2 || %ifos aix5.3 || %ifos aix6.1 || %ifos aix7.1
+%{_libdir}/libpgm.la
+%else
 %{_libdir}/libpgm.a
 %{_libdir}/libpgm.la
 %{_libdir}/libpgm.so
+%endif
 %{_libdir}/pkgconfig/openpgm-@RELEASE_INFO@.pc
 
 %changelog
+* Thu Sep 12 2013 Jim Hague <jim.hague@acm.org>
+- Adapting for AIX
+
 * Fri Apr 8 2011 Mikko Koppanen <mikko@kuut.io> 5.1.116-1
 - Initial packaging

--- a/openpgm/pgm/sockaddr.c
+++ b/openpgm/pgm/sockaddr.c
@@ -104,6 +104,9 @@ pgm_sockaddr_len (
 	const struct sockaddr*	sa
 	)
 {
+#ifdef HAVE_SOCKADDR_SA_LEN
+	return MAX(sa->sa_len, sizeof(struct sockaddr));
+#else
 	socklen_t sa_len;
 	switch (sa->sa_family) {
 	case AF_INET:	sa_len = sizeof(struct sockaddr_in); break;
@@ -111,6 +114,7 @@ pgm_sockaddr_len (
 	default:	sa_len = 0; break;
 	}
 	return sa_len;
+#endif /* HAVE_SOCKADDR_SA_LEN */
 }
 
 PGM_GNUC_INTERNAL

--- a/openpgm/pgm/tsi.c
+++ b/openpgm/pgm/tsi.c
@@ -112,7 +112,7 @@ pgm_tsi_equal (
 		pgm_tsi_t	tsi;
 		uint32_t	l[2];
 		uint64_t	ll;
-	} *restrict u1 = p1, *restrict u2 = p2;
+	} *u1 = p1, *u2 = p2;
 
 /* pre-conditions */
 	pgm_assert (NULL != p1);


### PR DESCRIPTION
* AIX uses a 3 parameter version of getprotobyname_r() and requires
  call to endprotoent_r() when finished.
* AIX network header files and structures differ in parts.
* xlc objects to some uses of restrict.
* Use AIX atomics.
* xlc 'pragma pack' handling needs adjustment.
* Remove AC_FUNC_MALLOC and AC_FUNC_REALLOC from autoconf build. They
  are only necessary for source bases where NULL returns from malloc/realloc()
  are not handled, and on platforms like AIX where malloc(0) returns NULL
  cause malloc/realloc to be renamed so a stub function can be implemented
  to correct malloc(0)->malloc(1). All unnecessary.
* Add fetch_and_add_h() implementation for xlc based on GCC builtin code.
* Rework interface enumeration with SIOCGIFCONF. AIX has to use it, and
  implements sa_len. Reworked SIOCGIFCONF code tested on Linux, FreeBSD,
  OpenSolaris and AIX.
* Modify .spec file for use with AIX as well as Linux.

Note building OpenPGM with scons is not supported for AIX.
xlc build tested with xlc v6. gcc build tested with gcc 4.6.3.