### PR TITLE
Allow clients to specify addresses to be used for send and receive in…

### DIFF
--- a/openpgm/pgm/examples/blocksyncrecv.c
+++ b/openpgm/pgm/examples/blocksyncrecv.c
@@ -267,12 +267,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/daytime.c
+++ b/openpgm/pgm/examples/daytime.c
@@ -381,13 +381,7 @@ create_sock (void)
 /* assign socket to specified address */
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
-	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),        /* tx interface */

--- a/openpgm/pgm/examples/enonblocksyncrecv.c
+++ b/openpgm/pgm/examples/enonblocksyncrecv.c
@@ -298,12 +298,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/enonblocksyncrecvmsg.c
+++ b/openpgm/pgm/examples/enonblocksyncrecvmsg.c
@@ -293,12 +293,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/enonblocksyncrecvmsgv.c
+++ b/openpgm/pgm/examples/enonblocksyncrecvmsgv.c
@@ -300,12 +300,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/pgmping.cc
+++ b/openpgm/pgm/examples/pgmping.cc
@@ -713,12 +713,7 @@ on_startup (
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/pgmrecv.c
+++ b/openpgm/pgm/examples/pgmrecv.c
@@ -378,12 +378,7 @@ on_startup (
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/pgmsend.c
+++ b/openpgm/pgm/examples/pgmsend.c
@@ -246,12 +246,7 @@ create_pgm_socket (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/pnonblocksyncrecv.c
+++ b/openpgm/pgm/examples/pnonblocksyncrecv.c
@@ -297,12 +297,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/purinrecv.c
+++ b/openpgm/pgm/examples/purinrecv.c
@@ -402,12 +402,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/purinsend.c
+++ b/openpgm/pgm/examples/purinsend.c
@@ -231,12 +231,7 @@ create_sock (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/examples/shortcakerecv.c
+++ b/openpgm/pgm/examples/shortcakerecv.c
@@ -350,12 +350,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),        /* tx interface */

--- a/openpgm/pgm/examples/snonblocksyncrecv.c
+++ b/openpgm/pgm/examples/snonblocksyncrecv.c
@@ -355,12 +355,7 @@ on_startup (void)
 	struct pgm_interface_req_t if_req;
 	memset (&if_req, 0, sizeof(if_req));
 	if_req.ir_interface = res->ai_recv_addrs[0].gsr_interface;
-	if_req.ir_scope_id  = 0;
-	if (AF_INET6 == sa_family) {
-		struct sockaddr_in6 sa6;
-		memcpy (&sa6, &res->ai_recv_addrs[0].gsr_group, sizeof(sa6));
-		if_req.ir_scope_id = sa6.sin6_scope_id;
-	}
+	memcpy (&if_req.ir_address, &res->ai_send_addrs[0].gsr_addr, sizeof(struct sockaddr_storage));
 	if (!pgm_bind3 (g_sock,
 			&addr, sizeof(addr),
 			&if_req, sizeof(if_req),	/* tx interface */

--- a/openpgm/pgm/if.c
+++ b/openpgm/pgm/if.c
@@ -807,20 +807,9 @@ skip_inet_network:
 			if ((ir->ir_flags & IFF_LOOPBACK) || !(ir->ir_flags & IFF_MULTICAST))
 				continue;
 
-/* check for multiple interfaces */
-			if (interface_matches++) {
-				pgm_set_error (error,
-					     PGM_ERROR_DOMAIN_IF,
-					     PGM_ERROR_NOTUNIQ,
-					     _("Network interface name not unique %s%s%s"),
-					     ifname ? "\"" : "", ifname ? ifname : "(null)", ifname ? "\"" : "");
-				pgm_freeifaddrs (ifap);
-				return FALSE;
-			}
-
+			interface_matches++;
 			ir->ir_interface = ifindex;
 			pgm_strncpy_s (ir->ir_name, IF_NAMESIZE, ifa->ifa_name, _TRUNCATE);
-			memcpy (&ir->ir_addr, ifa->ifa_addr, pgm_sockaddr_len (ifa->ifa_addr));
 			continue;
 		}
 	}
@@ -1139,7 +1128,7 @@ parse_receive_entity (
 	int			family,		/* AF_UNSPEC | AF_INET | AF_INET6 */
 	const char*   restrict	entity,		/* NULL terminated */
 	pgm_list_t**  restrict	interface_list,	/* <struct interface_req*> */
-	pgm_list_t**  restrict	recv_list,	/* <struct group_source_req*> */
+	pgm_list_t**  restrict	recv_list,	/* <struct pgm_group_source_req*> */
 	pgm_error_t** restrict	error
 	)
 {
@@ -1155,16 +1144,18 @@ parse_receive_entity (
 		(const void*)recv_list,
 		(const void*)error);
 
-	struct group_source_req* recv_gsr;
+	struct pgm_group_source_req* recv_gsr;
 	struct interface_req* primary_interface = (struct interface_req*)pgm_memdup ((*interface_list)->data, sizeof(struct interface_req));
 
 /* the empty entity */
 	if (NULL == entity)
 	{
 /* default receive object */
-		recv_gsr = pgm_new0 (struct group_source_req, 1);
+		recv_gsr = pgm_new0 (struct pgm_group_source_req, 1);
 		recv_gsr->gsr_interface = primary_interface->ir_interface;
 		recv_gsr->gsr_group.ss_family = family;
+		memcpy (&recv_gsr->gsr_addr, &primary_interface->ir_addr, pgm_sockaddr_len ((struct sockaddr *)&primary_interface->ir_addr));
+		
 
 /* track IPv6 scope from any resolved interface */
 		unsigned scope_id = 0;
@@ -1202,6 +1193,7 @@ parse_receive_entity (
 					}
 
 					recv_gsr->gsr_interface = ir.ir_interface;
+					memcpy (&recv_gsr->gsr_addr, &ir.ir_addr, pgm_sockaddr_len ((struct sockaddr*)&ir.ir_addr));
 					memcpy (&primary_interface->ir_addr, &ir.ir_addr, pgm_sockaddr_len ((struct sockaddr*)&ir.ir_addr));
 					scope_id = pgm_sockaddr_scope_id ((struct sockaddr*)&ir.ir_addr);
 				}
@@ -1211,6 +1203,7 @@ parse_receive_entity (
 /* use interface address family for multicast group */
 				recv_gsr->gsr_interface = primary_interface->ir_interface;
 				recv_gsr->gsr_group.ss_family = primary_interface->ir_addr.ss_family;
+				memcpy (&recv_gsr->gsr_addr, &primary_interface->ir_addr, pgm_sockaddr_len ((struct sockaddr*)&primary_interface->ir_addr));
 				scope_id = pgm_sockaddr_scope_id ((struct sockaddr*)&primary_interface->ir_addr);
 			}
 		}
@@ -1238,6 +1231,7 @@ parse_receive_entity (
 				}
 
 				recv_gsr->gsr_interface = ir.ir_interface;
+				memcpy (&recv_gsr->gsr_addr, &ir.ir_addr, pgm_sockaddr_len ((struct sockaddr*)&ir.ir_addr));
 				scope_id = pgm_sockaddr_scope_id ((struct sockaddr*)&ir.ir_addr);
 			}
 		}
@@ -1282,9 +1276,10 @@ parse_receive_entity (
 	while (tokens && tokens[j])
 	{
 /* default receive object */
-		recv_gsr = pgm_new0 (struct group_source_req, 1);
+		recv_gsr = pgm_new0 (struct pgm_group_source_req, 1);
 		recv_gsr->gsr_interface = primary_interface->ir_interface;
 		recv_gsr->gsr_group.ss_family = family;
+		memcpy (&recv_gsr->gsr_addr, &primary_interface->ir_addr, pgm_sockaddr_len ((struct sockaddr*)&primary_interface->ir_addr));
 
 		if (AF_UNSPEC == recv_gsr->gsr_group.ss_family)
 		{
@@ -1316,17 +1311,28 @@ parse_receive_entity (
 			if (primary_interface->ir_name[0] != '\0')
 			{
 				struct interface_req ir;
-				if (!parse_interface (recv_gsr->gsr_group.ss_family, primary_interface->ir_name, &ir, error))
+				pgm_error_t* sub_error = NULL;
+				if (!parse_interface (recv_gsr->gsr_group.ss_family, primary_interface->ir_name, &ir, &sub_error))
 				{
-					pgm_prefix_error (error,
-							_("Unique address cannot be determined for interface %s%s%s: "),
-							primary_interface->ir_name ? "\"" : "", primary_interface->ir_name ? primary_interface->ir_name : "(null)", primary_interface->ir_name ? "\"" : "");
-					pgm_free (recv_gsr);
-					pgm_free (primary_interface);
-					return FALSE;
+/* if multiple addresses on interface, use the first */
+					if (sub_error && PGM_ERROR_NOTUNIQ == sub_error->code)
+					{
+						pgm_error_free (sub_error);
+					}
+					else
+					{
+						pgm_propagate_error (error, sub_error);
+						pgm_prefix_error (error,
+								  _("Unique address cannot be determined for interface %s%s%s: "),
+								  primary_interface->ir_name ? "\"" : "", primary_interface->ir_name ? primary_interface->ir_name : "(null)", primary_interface->ir_name ? "\"" : "");
+						pgm_free (recv_gsr);
+						pgm_free (primary_interface);
+						return FALSE;
+					}
 				}
 
 				recv_gsr->gsr_interface = ir.ir_interface;
+				memcpy (&recv_gsr->gsr_addr, &ir.ir_addr, pgm_sockaddr_len ((struct sockaddr*)&ir.ir_addr));
 				((struct sockaddr_in6*)&recv_gsr->gsr_group)->sin6_scope_id = pgm_sockaddr_scope_id ((struct sockaddr*)&ir.ir_addr);
 			}
 		}
@@ -1361,8 +1367,8 @@ parse_send_entity (
 	int			family,		/* AF_UNSPEC | AF_INET | AF_INET6 */
 	const char*   restrict	entity,		/* null = empty entity */
 	pgm_list_t**  restrict	interface_list,	/* <struct interface_req*> */
-	pgm_list_t**  restrict	recv_list,	/* <struct group_source_req*> */
-	pgm_list_t**  restrict	send_list,	/* <struct group_source_req*> */
+	pgm_list_t**  restrict	recv_list,	/* <struct pgm_group_source_req*> */
+	pgm_list_t**  restrict	send_list,	/* <struct pgm_group_source_req*> */
 	pgm_error_t** restrict	error
 	)
 {
@@ -1381,19 +1387,20 @@ parse_send_entity (
 		(const void*)send_list,
 		(const void*)error);
 
-	struct group_source_req* send_gsr;
+	struct pgm_group_source_req* send_gsr;
 	const struct interface_req* primary_interface = (struct interface_req*)(*interface_list)->data;
 
 	if (entity == NULL)
 	{
-		send_gsr = pgm_memdup ((*recv_list)->data, sizeof(struct group_source_req));
+		send_gsr = pgm_memdup ((*recv_list)->data, sizeof(struct pgm_group_source_req));
 		*send_list = pgm_list_append (*send_list, send_gsr);
 		return TRUE;
 	}
 
 /* default send object */
-	send_gsr = pgm_new0 (struct group_source_req, 1);
+	send_gsr = pgm_new0 (struct pgm_group_source_req, 1);
 	send_gsr->gsr_interface = primary_interface->ir_interface;
+	memcpy (&send_gsr->gsr_addr, &primary_interface->ir_addr, pgm_sockaddr_len ((struct sockaddr*)&primary_interface->ir_addr));
 	if (!parse_group (family, entity, (struct sockaddr*)&send_gsr->gsr_group, error))
 	{
 		pgm_prefix_error (error,
@@ -1420,6 +1427,7 @@ parse_send_entity (
 
 			send_gsr->gsr_interface = ir.ir_interface;
 			((struct sockaddr_in6*)&send_gsr->gsr_group)->sin6_scope_id = pgm_sockaddr_scope_id ((struct sockaddr*)&ir.ir_addr);
+			memcpy (&send_gsr->gsr_addr, &ir.ir_addr, pgm_sockaddr_len ((struct sockaddr*)&ir.ir_addr));
 		}
 	}
 
@@ -1499,8 +1507,8 @@ bool
 network_parse (
 	const char*   restrict	network,		/* NULL terminated */
 	int			family,			/* AF_UNSPEC | AF_INET | AF_INET6 */
-	pgm_list_t**  restrict	recv_list,		/* <struct group_source_req*> */
-	pgm_list_t**  restrict	send_list,		/* <struct group_source_req*> */
+	pgm_list_t**  restrict	recv_list,		/* <struct pgm_group_source_req*> */
+	pgm_list_t**  restrict	send_list,		/* <struct pgm_group_source_req*> */
 	pgm_error_t** restrict	error
 	)
 {
@@ -1734,7 +1742,7 @@ free_lists:
 	return FALSE;
 }
 
-/* create group_source_req as used by pgm_transport_create which specify port, address & interface.
+/* create pgm_group_source_req as used by pgm_transport_create which specify port, address & interface.
  * gsr_source is copied from gsr_group for ASM, caller needs to populate gsr_source for SSM.
  *
  * returns TRUE on success, returns FALSE on error and sets error appropriately.
@@ -1750,8 +1758,8 @@ pgm_getaddrinfo (
 {
 	struct pgm_addrinfo_t* ai;
 	const int family = hints ? hints->ai_family : AF_UNSPEC;
-	pgm_list_t* recv_list = NULL;	/* <struct group_source_req*> */
-	pgm_list_t* send_list = NULL;	/* <struct group_source_req*> */
+	pgm_list_t* recv_list = NULL;	/* <struct pgm_group_source_req*> */
+	pgm_list_t* send_list = NULL;	/* <struct pgm_group_source_req*> */
 
 	pgm_return_val_if_fail (NULL != network, FALSE);
 	pgm_return_val_if_fail (AF_UNSPEC == family || AF_INET == family || AF_INET6 == family, FALSE);
@@ -1776,21 +1784,21 @@ pgm_getaddrinfo (
 	const size_t recv_list_len = pgm_list_length (recv_list);
 	const size_t send_list_len = pgm_list_length (send_list);
 	ai = pgm_malloc0 (sizeof(struct pgm_addrinfo_t) + 
-			 (recv_list_len + send_list_len) * sizeof(struct group_source_req));
+			 (recv_list_len + send_list_len) * sizeof(struct pgm_group_source_req));
 	ai->ai_recv_addrs_len = (uint32_t)recv_list_len;
 	ai->ai_recv_addrs = (void*)((char*)ai + sizeof(struct pgm_addrinfo_t));
 	ai->ai_send_addrs_len = (uint32_t)send_list_len;
-	ai->ai_send_addrs = (void*)((char*)ai->ai_recv_addrs + recv_list_len * sizeof(struct group_source_req));
+	ai->ai_send_addrs = (void*)((char*)ai->ai_recv_addrs + recv_list_len * sizeof(struct pgm_group_source_req));
 
 	size_t i = 0;
 	while (recv_list) {
-		memcpy (&ai->ai_recv_addrs[i++], recv_list->data, sizeof(struct group_source_req));
+		memcpy (&ai->ai_recv_addrs[i++], recv_list->data, sizeof(struct pgm_group_source_req));
 		pgm_free (recv_list->data);
 		recv_list = pgm_list_delete_link (recv_list, recv_list);
 	}
 	i = 0;
 	while (send_list) {
-		memcpy (&ai->ai_send_addrs[i++], send_list->data, sizeof(struct group_source_req));
+		memcpy (&ai->ai_send_addrs[i++], send_list->data, sizeof(struct pgm_group_source_req));
 		pgm_free (send_list->data);
 		send_list = pgm_list_delete_link (send_list, send_list);
 	}

--- a/openpgm/pgm/include/pgm/socket.h
+++ b/openpgm/pgm/include/pgm/socket.h
@@ -55,15 +55,26 @@ struct pgm_sockaddr_t {
 struct pgm_addrinfo_t {
 	sa_family_t				ai_family;
 	uint32_t				ai_recv_addrs_len;
-	struct group_source_req* restrict	ai_recv_addrs;
+	struct pgm_group_source_req* restrict	ai_recv_addrs;
 	uint32_t				ai_send_addrs_len;
-	struct group_source_req* restrict	ai_send_addrs;
+	struct pgm_group_source_req* restrict	ai_send_addrs;
+};
+
+struct pgm_group_source_req
+{
+	uint32_t		gsr_interface;	/* interface index */
+	struct sockaddr_storage	gsr_group;	/* group address */
+	struct sockaddr_storage	gsr_source;	/* group source */
+	struct sockaddr_storage	gsr_addr;	/* interface address */
 };
 
 struct pgm_interface_req_t {
 	uint32_t				ir_interface;
 	uint32_t				ir_scope_id;
+	struct sockaddr_storage			ir_address;
 };
+
+#define	PGM_HAS_IR_ADDRESS	1
 
 struct pgm_fecinfo_t {
 	uint8_t					block_size;

--- a/openpgm/pgm/socket.c
+++ b/openpgm/pgm/socket.c
@@ -2166,7 +2166,9 @@ pgm_bind3 (
 		pgm_trace (PGM_LOG_ROLE_NETWORK,_("Binding receive socket to IN6ADDR_ANY"));
 	}
 #else
-	if (!pgm_if_indextoaddr (recv_req->ir_interface,
+	if (recv_req->ir_address.ss_family != AF_UNSPEC)
+		memcpy(&recv_addr, &recv_req->ir_address, pgm_sockaddr_len (recv_req->ir_address));
+	else if (!pgm_if_indextoaddr (recv_req->ir_interface,
 			         sock->family,
 				 recv_req->ir_scope_id,
 			         &recv_addr.sa,
@@ -2221,7 +2223,9 @@ pgm_bind3 (
 /* keep a copy of the original address source to re-use for router alert bind */
 	memset (&send_addr, 0, sizeof(send_addr));
 
-	if (!pgm_if_indextoaddr (send_req->ir_interface,
+	if (send_req->ir_address.ss_family != AF_UNSPEC)
+		memcpy(&send_addr, &send_req->ir_address, pgm_sockaddr_len ((struct sockaddr *)&send_req->ir_address));
+	else if (!pgm_if_indextoaddr (send_req->ir_interface,
 				 sock->family,
 				 send_req->ir_scope_id,
 				 (struct sockaddr*)&send_addr,


### PR DESCRIPTION
Add an extra field ir_address to pgm_interface_req_t and define preprocessor
symbol PGM_HAS_IR_ADDRESS so a client can know it is present. Also add
the address to the information returned by pgm_getaddrinfo(), so that different
addresses on a single network device can be specified.

Also modify interface name parsing to allow for interfaces to have more
than one address.

When binding, if the address family is not AF_UNDEF, the address will be
used for underlying socket binding, rather than using the first address
on the interface indexed by ir_interface.

To match this, define pgm_group_source_req, add gsr_addr and use that in
pgm_addrinfo_t instead of group_source_req.