### PR TITLE
call setgroups() before setuid()

### DIFF
--- a/openpgm/pgm/engine.c
+++ b/openpgm/pgm/engine.c
@@ -262,6 +262,7 @@ pgm_drop_superuser (void)
 {
 #ifndef _WIN32
 	if (0 == getuid()) {
+		setgroups(0, NULL);
 		setuid((gid_t)65534);
 		setgid((uid_t)65534);
 	}

--- a/openpgm/pgm/examples/pgmdump.c
+++ b/openpgm/pgm/examples/pgmdump.c
@@ -169,6 +169,7 @@ on_startup (
 /* drop out of setuid 0 */
 	if (0 == getuid ()) {
 		g_message ("dropping superuser privileges.");
+		setgroups(0, NULL);
 		setuid ((gid_t)65534);
 		setgid ((uid_t)65534);
 	}

--- a/openpgm/pgm/examples/pgmtop.c
+++ b/openpgm/pgm/examples/pgmtop.c
@@ -625,6 +625,7 @@ on_startup (
 /* drop out of setuid 0 */
 	if (0 == getuid ()) {
 		puts ("dropping superuser privileges.");
+		setgroups(0, NULL);
 		setuid ((gid_t)65534);
 		setgid ((uid_t)65534);
 	}

--- a/openpgm/pgm/test/monitor.c
+++ b/openpgm/pgm/test/monitor.c
@@ -221,6 +221,7 @@ on_startup (
 /* drop out of setuid 0 */
 	if (0 == getuid()) {
 		puts ("dropping superuser privileges.");
+		setgroups(0, NULL);
 		setuid((gid_t)65534);
 		setgid((uid_t)65534);
 	}


### PR DESCRIPTION
When dropping privileges from root, the `setgroups` call will remove any extraneous groups. If we don't call this, then even though our uid has dropped, we may still have groups that enable us to do super-user things.

Fixes #36