### PR TITLE
Rework defines to fix build with musl libc

### DIFF
--- a/openpgm/pgm/include/impl/security.h
+++ b/openpgm/pgm/include/impl/security.h
@@ -33,7 +33,6 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <sys/types.h>
-#include <sys/timeb.h>
 #include <impl/i18n.h>
 #include <impl/errno.h>
 #include <impl/string.h>
@@ -41,6 +40,8 @@
 PGM_BEGIN_DECLS
 
 #ifdef HAVE_FTIME
+#include <sys/timeb.h>
+
 static inline
 errno_t
 #	if   !defined( _WIN32 )

--- a/openpgm/pgm/include/pgm/types.h
+++ b/openpgm/pgm/include/pgm/types.h
@@ -27,6 +27,7 @@
 
 #ifndef _MSC_VER
 #	include <sys/param.h>
+#	include <sys/types.h>
 #endif
 #include <pgm/macros.h>
 


### PR DESCRIPTION
Downloaded patch from
http://git.alpinelinux.org/cgit/aports/plain/main/openpgm/openpgm-fix-includes.patch
and adjusted paths by prefixing with "openpgm/pgm/"

A build log with the compile error can be found here:
http://autobuild.buildroot.net/results/854/854554827ead82f29b293ddceced6eb7fbfeec27/build-end.log

Signed-off-by: Bernd Kuhls <bernd.kuhls@t-online.de>