### PR TITLE
allow to override build date

### DIFF
--- a/openpgm/pgm/version_generator.py
+++ b/openpgm/pgm/version_generator.py
@@ -4,8 +4,9 @@ import os
 import platform
 import time
 
-build_date = time.strftime ("%Y-%m-%d")
-build_time = time.strftime ("%H:%M:%S")
+timestamp = time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+build_date = time.strftime ("%Y-%m-%d", timestamp)
+build_time = time.strftime ("%H:%M:%S", timestamp)
 build_rev = ''.join (list (filter (str.isdigit, "$Revision$")))
 
 print ("""


### PR DESCRIPTION
to enable reproducible builds.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.