### PR TITLE
Problem: does not build under Mac OS X 10.11.6

### DIFF
--- a/openpgm/pgm/checksum.c
+++ b/openpgm/pgm/checksum.c
@@ -870,7 +870,7 @@ do_csum_mmx (
 	const __m64 zero = _mm_setzero_si64();
 	__m64 sum = zero;
 	while (count8--) {
-#if 1
+#if 0
 		__m64 tmp = _mm_set_pi64x(*(const int64_t*)buf);
 #else
 		__m64 tmp = _mm_set_pi32(((const int*)buf)[1], ((const int*)buf)[0]);	// load 64-bit as 2×32-bit
@@ -936,7 +936,7 @@ do_csumcpy_mmx (
 	count8 = len >> 3;
 	__m64 sum = _mm_setzero_si64();
 	while (count8--) {
-#if 1
+#if 0
 		__m64 tmp = _mm_set_pi64x(*(const int64_t*)src);
 #else
 		__m64 tmp = _mm_set_pi32(((const int*)src)[1], ((const int*)src)[0]);	// load 64-bit as 2×32-bit

--- a/openpgm/pgm/socket.c
+++ b/openpgm/pgm/socket.c
@@ -2208,7 +2208,7 @@ pgm_bind3 (
 	}
 #else
 	if (recv_req->ir_address.ss_family != AF_UNSPEC)
-		memcpy(&recv_addr, &recv_req->ir_address, pgm_sockaddr_len (recv_req->ir_address));
+		memcpy(&recv_addr, &recv_req->ir_address, pgm_sockaddr_len (&recv_req->ir_address));
 	else if (!pgm_if_indextoaddr (recv_req->ir_interface,
 			         sock->family,
 				 recv_req->ir_scope_id,

--- a/openpgm/pgm/version_generator.py
+++ b/openpgm/pgm/version_generator.py
@@ -4,7 +4,7 @@ import os
 import platform
 import time
 
-timestamp = time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+timestamp = time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
 build_date = time.strftime ("%Y-%m-%d", timestamp)
 build_time = time.strftime ("%H:%M:%S", timestamp)
 build_rev = ''.join (list (filter (str.isdigit, "$Revision$")))
@@ -54,3 +54,4 @@ const char* pgm_build_revision = "{4}";
 """.format (build_date, build_time, platform.system(), platform.machine(), build_rev))
 
 # end of file
+


### PR DESCRIPTION
Solution: adapt checksum.c, socket.c to Mac OS X requirements, fixed syntax error in version_generator.py

Fixes #45 

@steve-o Please check the changes in the .c files if they can be applied generally. The #if guarded parts should probably better be based on some define. 

