### PR TITLE
Add more control over socket options

### DIFF
--- a/openpgm/pgm/socket.c
+++ b/openpgm/pgm/socket.c
@@ -478,8 +478,12 @@ pgm_socket (
  */
 		pgm_trace (PGM_LOG_ROLE_NETWORK,_("Set socket sharing."));
 		const int v = 1;
-#ifndef SO_REUSEPORT
-		if (SOCKET_ERROR == setsockopt (new_sock->recv_sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&v, sizeof(v)) ||
+                const int ip_mcast_all = 0; // turn off
+#if !defined(SO_REUSEPORT) || defined(DISABLE_REUSEPORT)
+                if (SOCKET_ERROR == setsockopt (new_sock->recv_sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&v, sizeof(v)) ||
+#if defined(DISABLE_IP_MULTICAST_ALL)
+                    SOCKET_ERROR == setsockopt (new_sock->recv_sock, IPPROTO_IP, IP_MULTICAST_ALL, (const char*)&ip_mcast_all, sizeof(ip_mcast_all)) ||        
+#endif
 		    SOCKET_ERROR == setsockopt (new_sock->send_sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&v, sizeof(v)) ||
 		    SOCKET_ERROR == setsockopt (new_sock->send_with_router_alert_sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&v, sizeof(v)))
 		{

--- a/openpgm/pgm/version_generator.py
+++ b/openpgm/pgm/version_generator.py
@@ -4,7 +4,7 @@ import os
 import platform
 import time
 
-timestamp = time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+timestamp = time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
 build_date = time.strftime ("%Y-%m-%d", timestamp)
 build_time = time.strftime ("%H:%M:%S", timestamp)
 build_rev = ''.join (list (filter (str.isdigit, "$Revision$")))


### PR DESCRIPTION
**DISABLE_REUSEPORT** 
With the introduction of `SO_REUSEPORT` in linux kernel 3.9 and the backport to red hat 6.5 the `SO_REUSEPORT` socket option is enabled with no option to disable. The linux socket option differs from the original BSD as it allows load balancing across sockets and also restrict reusing ports to processes owned by the same user. The define `DISABLE_REUSEPORT` allows the the option to be disabled at compile time.
[More Info](https://stackoverflow.com/questions/14388706/socket-options-so-reuseaddr-and-so-reuseport-how-do-they-differ-do-they-mean-t)

**DISABLE_IP_MULTICAST_ALL**
Openpgm always uses the `INADDR_ANY` interface address for encapsulated pgm (to allow both mcast and unicast?). This has the side effect of receiving any other multicast data (even joined by another process with a different address) if they share the same port.  `DISABLE_IP_MULTICAST_ALL` sets socket option `IP_MULTICAST_ALL` to off, this specifies the socket will only get multicast data for the addresses it has explicitly joined.
[more details](http://man7.org/linux/man-pages/man7/ip.7.html)