### PR TITLE
pkg-config: do not add -I to non-existing directory

### DIFF
--- a/openpgm/pgm/openpgm-5.2.pc.in
+++ b/openpgm/pgm/openpgm-5.2.pc.in
@@ -9,4 +9,4 @@ Version: @PACKAGE_VERSION@
 # packagers may wish to move @LIBS@ to Libs.private for platforms with
 # versions of pkg-config that support static linking.
 Libs: -L${libdir} -lpgm @LIBS@
-Cflags: -I${includedir}/pgm-@VERSION_MAJOR@.@VERSION_MINOR@ -I${libdir}/pgm-@VERSION_MAJOR@.@VERSION_MINOR@/include
+Cflags: -I${includedir}/pgm-@VERSION_MAJOR@.@VERSION_MINOR@


### PR DESCRIPTION
foo/lib/pgm-5.2/include does not exist, so applications using strict
compiler flags will fail to build due to this -I flag