### PR TITLE
configure rdtsc checking chg required for LTO

### DIFF
--- a/openpgm/pgm/configure.ac
+++ b/openpgm/pgm/configure.ac
@@ -187,7 +187,7 @@ darwin* | aix*)
 	AC_MSG_RESULT([no])
 	;;
 *)
-AC_COMPILE_IFELSE(
+AC_LINK_IFELSE(
 	[AC_LANG_PROGRAM(,[[unsigned long lo, hi;
 __asm__ __volatile__ ("rdtsc" : "=a" (lo), "=d" (hi));]])],
 :1


### PR DESCRIPTION
To avoid rdtsc to be enabled  when not required
(for PowerPC ARM) when LTO is enabled; eg openSUSE:
https://build.opensuse.org/package/show/devel:libraries:c_c++/openpgm

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>