### PR TITLE
Modernization for newer versions of GCC

### DIFF
--- a/openpgm/pgm/.gitignore
+++ b/openpgm/pgm/.gitignore
@@ -3,3 +3,6 @@ build/
 config.log
 ref/
 scons.signatures-*.dblite
+autom4te.cache/
+/configure
+/include/config.h

--- a/openpgm/pgm/SConscript.autoconf
+++ b/openpgm/pgm/SConscript.autoconf
@@ -288,6 +288,7 @@ def AutoConf (env):
 	settings['HAVE_CLOCK_GETTIME'] = conf.CheckFunc ('clock_gettime');
 	settings['HAVE_FTIME'] = conf.CheckFunc ('ftime');
 	settings['HAVE_GETTIMEOFDAY'] = conf.CheckFunc ('gettimeofday');
+	settings['HAVE_TIMESPEC_GET'] = conf.CheckFunc ('timespec_get');
 	# Custom checks
 	settings['HAVE_PTHREAD_SPINLOCK'] = conf.CheckPthreadSpinlock();
 	settings['HAVE_GETPROTOBYNAME_R'] = conf.CheckFunc ('getprotobyname_r');

--- a/openpgm/pgm/SConscript.autoconf
+++ b/openpgm/pgm/SConscript.autoconf
@@ -113,7 +113,7 @@ def CheckMember (context, member, header):
 int
 main ()
 {
-	offsetof (""" + string.replace (member, '.', ', ') + """);
+	offsetof (""" + member.replace('.', ', ') + """);
 	return 0;
 }
 	"""

--- a/openpgm/pgm/SConstruct
+++ b/openpgm/pgm/SConstruct
@@ -202,15 +202,15 @@ if env['WITH_SNMP'] == 'true':
 conf = Configure(env, custom_tests = tests);
 
 if env['WITH_SNMP'] == 'true' and not conf.CheckSNMP():
-	print 'Net-SNMP libraries not compatible.';
+	print ('Net-SNMP libraries not compatible.');
 	Exit(1);
 
 if env['WITH_CHECK'] == 'true' and conf.CheckCheck():
-	print 'Enabling Check unit tests.';
+	print ('Enabling Check unit tests.');
 	conf.env['CHECK'] = 'true';
 	env['CHECK_FLAGS'] = env.ParseFlags('!pkg-config --cflags --libs check');
 else:
-	print 'Disabling Check unit tests.';
+	print ('Disabling Check unit tests.');
 	conf.env['CHECK'] = 'false';
 
 env = conf.Finish();

--- a/openpgm/pgm/SConstruct
+++ b/openpgm/pgm/SConstruct
@@ -112,7 +112,7 @@ release = env.Clone(BUILD = 'release')
 release.Append(CCFLAGS = '-O2')
 
 debug = env.Clone(BUILD = 'debug')
-debug.Append(CCFLAGS = ['-DPGM_DEBUG','-ggdb'], LINKFLAGS = '-gdb')
+debug.Append(CCFLAGS = ['-DPGM_DEBUG','-ggdb'], LINKFLAGS = '-ggdb')
 
 profile = env.Clone(BUILD = 'profile')
 profile.Append(CCFLAGS = ['-O2','-pg'], LINKFLAGS = '-pg')
@@ -232,7 +232,7 @@ env.Append(BUILDERS = {'StaticSharedLibrary': pic_lib});
 #-----------------------------------------------------------------------------
 
 ref_node = 'ref/' + env['BUILD'] + '-' + platform.system() + '-' + platform.machine() + '/';
-BuildDir(ref_node, '.', duplicate=0)
+VariantDir(ref_node, '.', duplicate=0)
 
 env.Append(CPPPATH = [
 # $(top_builddir)/include

--- a/openpgm/pgm/engine.c
+++ b/openpgm/pgm/engine.c
@@ -271,8 +271,8 @@ pgm_drop_superuser (void)
 #ifndef _WIN32
 	if (0 == getuid()) {
 		setgroups(0, NULL);
-		setuid((gid_t)65534);
-		setgid((uid_t)65534);
+		setgid((gid_t)65534);
+		setuid((uid_t)65534);
 	}
 #endif
 }

--- a/openpgm/pgm/include/impl/messages.h
+++ b/openpgm/pgm/include/impl/messages.h
@@ -185,14 +185,14 @@ static inline void pgm_fatal (const char* format, ...) {
 #define pgm_warn_if_reached() \
 	do { \
 		pgm_warn ("file %s: line %d (%s): code should not be reached", \
-				__FILE__, __LINE__, __PRETTY_FUNCTION__); \
+				__FILE__, __LINE__, __func__); \
 	} while (0)
 #define pgm_warn_if_fail(expr) \
 	do { \
 		if (PGM_LIKELY (expr)); \
 		else \
 			pgm_warn ("file %s: line %d (%s): runtime check failed: (%s)", \
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, #expr); \
+				__FILE__, __LINE__, __func__, #expr); \
 	} while (0)
 
 
@@ -210,14 +210,14 @@ static inline void pgm_fatal (const char* format, ...) {
 		if (PGM_LIKELY(expr)); \
 		else { \
 			pgm_fatal ("file %s: line %d (%s): assertion failed: (%s)", \
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, #expr); \
+				__FILE__, __LINE__, __func__, #expr); \
 			abort (); \
 		} \
 	} while (0)
 #	define pgm_assert_not_reached() \
 	do { \
 		pgm_fatal ("file %s: line %d (%s): should not be reached", \
-			__FILE__, __LINE__, __PRETTY_FUNCTION__); \
+			__FILE__, __LINE__, __func__); \
 		abort (); \
 	} while (0)
 #	define pgm_assert_cmpint(n1, cmp, n2) \
@@ -226,7 +226,7 @@ static inline void pgm_fatal (const char* format, ...) {
 		if (PGM_LIKELY(_n1 cmp _n2)); \
 		else { \
 			pgm_fatal ("file %s: line %d (%s): assertion failed (%s): (%" PRIi64 " %s %" PRIi64 ")", \
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, #n1 " " #cmp " " #n2, _n1, #cmp, _n2); \
+				__FILE__, __LINE__, __func__, #n1 " " #cmp " " #n2, _n1, #cmp, _n2); \
 			abort (); \
 		} \
 	} while (0)
@@ -236,7 +236,7 @@ static inline void pgm_fatal (const char* format, ...) {
 		if (PGM_LIKELY(_n1 cmp _n2)); \
 		else { \
 			pgm_fatal ("file %s: line %d (%s): assertion failed (%s): (%" PRIu64 " %s %" PRIu64 ")", \
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, #n1 " " #cmp " " #n2, _n1, #cmp, _n2); \
+				__FILE__, __LINE__, __func__, #n1 " " #cmp " " #n2, _n1, #cmp, _n2); \
 			abort (); \
 		} \
 	} while (0)
@@ -295,7 +295,7 @@ static inline void pgm_fatal (const char* format, ...) {
 		if (PGM_LIKELY(expr)); \
 		else { \
 			pgm_warn ("file %s: line %d (%s): assertion `%s' failed", \
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, #expr); \
+				__FILE__, __LINE__, __func__, #expr); \
 			return; \
 		} \
 	} while (0)
@@ -304,20 +304,20 @@ static inline void pgm_fatal (const char* format, ...) {
 		if (PGM_LIKELY(expr)); \
 		else { \
 			pgm_warn ("file %s: line %d (%s): assertion `%s' failed", \
-				__FILE__, __LINE__, __PRETTY_FUNCTION__, #expr); \
+				__FILE__, __LINE__, __func__, #expr); \
 			return (val); \
 		} \
 	} while (0)
 #	define pgm_return_if_reached() \
 	do { \
 		pgm_warn ("file %s: line %d (%s): should not be reached", \
-			__FILE__, __LINE__, __PRETTY_FUNCTION__); \
+			__FILE__, __LINE__, __func__); \
 		return; \
 	} while (0)
 #	define pgm_return_val_if_reached(val) \
 	do { \
 		pgm_warn ("file %s: line %d (%s): should not be reached", \
-			__FILE__, __LINE__, __PRETTY_FUNCTION__); \
+			__FILE__, __LINE__, __func__); \
 		return (val); \
 	} while (0)
 

--- a/openpgm/pgm/mem.c
+++ b/openpgm/pgm/mem.c
@@ -163,7 +163,7 @@ pgm_malloc (
 
 #ifdef __GNUC__
 		pgm_fatal ("file %s: line %d (%s): failed to allocate %" PRIzu " bytes",
-			__FILE__, __LINE__, __PRETTY_FUNCTION__,
+			__FILE__, __LINE__, __func__,
 			n_bytes);
 #else
 		pgm_fatal ("file %s: line %d: failed to allocate %" PRIzu " bytes",
@@ -186,7 +186,7 @@ pgm_malloc_n (
 	if (SIZE_OVERFLOWS (n_blocks, block_bytes)) {
 #ifdef __GNUC__
 		pgm_fatal ("file %s: line %d (%s): overflow allocating %" PRIzu "*%" PRIzu " bytes",
-			__FILE__, __LINE__, __PRETTY_FUNCTION__,
+			__FILE__, __LINE__, __func__,
 			n_blocks, block_bytes);
 #else
 		pgm_fatal ("file %s: line %d: overflow allocating %" PRIzu "*%" PRIzu " bytes",
@@ -210,7 +210,7 @@ pgm_malloc0 (
 
 #ifdef __GNUC__
 		pgm_fatal ("file %s: line %d (%s): failed to allocate %" PRIzu " bytes",
-			__FILE__, __LINE__, __PRETTY_FUNCTION__,
+			__FILE__, __LINE__, __func__,
 			n_bytes);
 #else
 		pgm_fatal ("file %s: line %d: failed to allocate %" PRIzu " bytes",
@@ -236,7 +236,7 @@ pgm_malloc0_n (
 
 #ifdef __GNUC__
 		pgm_fatal ("file %s: line %d (%s): failed to allocate %" PRIzu "*%" PRIzu " bytes",
-			__FILE__, __LINE__, __PRETTY_FUNCTION__,
+			__FILE__, __LINE__, __func__,
 			n_blocks, block_bytes);
 #else
 		pgm_fatal ("file %s: line %d: failed to allocate %" PRIzu "*%" PRIzu " bytes",

--- a/openpgm/pgm/version_generator.py
+++ b/openpgm/pgm/version_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 import platform


### PR DESCRIPTION
Though It spits a lot of warnings, that new (suggested) version successfully builds on at least CentOS 8.
Progress for RedHat/CentOS/Fedora may be followed on https://src.fedoraproject.org/rpms/openpgm
