### PR TITLE
openpgm/pgm/checksum.c: fix build with 32 bits MMX

### DIFF
--- a/openpgm/pgm/checksum.c
+++ b/openpgm/pgm/checksum.c
@@ -948,7 +948,7 @@ do_csumcpy_mmx (
 
 		sum = _mm_add_pi32 (sum, lo);
 		sum = _mm_add_pi32 (sum, hi);
-#if 1
+#if defined(__x86_64__)
 		*(int64_t*)dst = _mm_cvtm64_si64 (tmp);
 #else		
 		((int*)dst)[1] = _mm_cvtsi64_si32 (tmp);


### PR DESCRIPTION
Build with i386-pentium-mmx or i686 is broken since version 5-3-128 and https://github.com/steve-o/openpgm/commit/b276dc15be5d4e6e1143b9de25d09f63f9c85135 because `_mm_cvtm64_si64` is undefined resulting in the following build failure for example on zeromq:

```
/srv/storage/autobuild/run/instance-3/output-1/host/opt/ext-toolchain/bin/../lib/gcc/i586-buildroot-linux-musl/8.3.0/../../../../i586-buildroot-linux-musl/bin/ld: /srv/storage/autobuild/run/instance-3/output-1/host/i586-buildroot-linux-musl/sysroot/usr/lib32/libpgm-5.3.so.0: undefined reference to `_mm_cvtm64_si64'
```

So use the fallback if `__x86_64__` is not defined

Fixes:
 - http://autobuild.buildroot.org/results/01d9be37e8a743307128f53f41785654c9971e1a

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>