### PR TITLE
fix build on macOS ARM

### DIFF
--- a/openpgm/pgm/cpu.c
+++ b/openpgm/pgm/cpu.c
@@ -33,6 +33,7 @@
 //#define CPU_DEBUG
 
 
+#if defined(__i386__) || defined(__x86_64__)
 #ifndef _MSC_VER
 static
 void
@@ -59,7 +60,6 @@ _xgetbv(uint32_t xcr) {
 #endif
 
 
-#if defined(__i386__) || defined(__x86_64__)
 PGM_GNUC_INTERNAL
 void
 pgm_cpuid (pgm_cpu_t* cpu)


### PR DESCRIPTION
During update of `libpgm` Homebrew package Homebrew/homebrew-core#95457, the following macOS M1/ARM build failures were seen during `make`:
```
cpu.c:44:7: error: invalid output constraint '=a' in asm
    : "=a"(cpu_info[0]), "=D"(cpu_info[1]), "=c"(cpu_info[2]), "=d"(cpu_info[3])
      ^
cpu.c:56:16: error: invalid output constraint '=a' in asm
    "xgetbv" : "=a"(eax), "=d"(edx) : "c"(xcr));
               ^
5 warnings and 2 errors generated.
make: *** [libpgm_noinst_la-cpu.lo] Error 1
```

---

The simple fix here is to avoid the incompatible assembly code inside `__cpuidex` & `_xgetbv` since they are only used within a i386/x86_64-conditional section from https://github.com/steve-o/openpgm/commit/9730e05169ca819ee27f66deb52e4ae1828f7267
